### PR TITLE
Fixed break line problem when invalid arguments are given

### DIFF
--- a/src/main/java/dbdia/Main.java
+++ b/src/main/java/dbdia/Main.java
@@ -69,7 +69,7 @@ public enum Main {
           System.err.println(VERSION);
           break;
         default:
-          System.err.print("Invalid arguments. Execute 'dbdia help' for help.%n");
+          System.err.printf("Invalid arguments. Execute 'dbdia help' for help.%n");
           System.exit(1);
       }
       System.exit(0);


### PR DESCRIPTION
While using the terminal interface I noticed a problem with the break line at the end of the sentence when invalid arguments are given. I know it's a simple thing, but anyways...